### PR TITLE
Fix crash when selecting multiple units

### DIFF
--- a/horizons/gui/tabs/selectmultitab.py
+++ b/horizons/gui/tabs/selectmultitab.py
@@ -89,7 +89,7 @@ class SelectMultiTab(TabInterface):
 			self.row_number = 2
 			return
 		self.column_number += 1
-		self.widget.findChild(name="hbox_{}".format(self.row_number).addChild(entry.widget))
+		self.widget.findChild(name="hbox_{}".format(self.row_number)).addChild(entry.widget)
 		self.entries.append(entry)
 
 	def draw_selected_units_widget(self):


### PR DESCRIPTION
Traceback (most recent call last):
 File "/disk/src/github/unknown-horizons/unknown-horizons/horizons/gui/mousetools/selectiontool.py", line 129, in mouseReleased
    self.apply_select()
 File "/disk/src/github/unknown-horizons/unknown-horizons/horizons/gui/mousetools/selectiontool.py", line 153, in apply_select
    self.session.ingame_gui.show_multi_select_tab(selected)
 File "/disk/src/github/unknown-horizons/unknown-horizons/horizons/gui/ingamegui.py", line 245, in show_multi_select_tab
    tab = TabWidget(self, tabs=[SelectMultiTab(instances)], name='select_multi')
 File "/disk/src/github/unknown-horizons/unknown-horizons/horizons/gui/tabs/tabwidget.py", line 53, in __init__
    self.current_tab.ensure_loaded() # loading current_tab widget
 File "/disk/src/github/unknown-horizons/unknown-horizons/horizons/gui/tabs/tabinterface.py", line 163, in ensure_loaded
    self._setup_widget()
 File "/disk/src/github/unknown-horizons/unknown-horizons/horizons/gui/tabs/tabinterface.py", line 102, in _setup_widget
    self.init_widget()
 File "/disk/src/github/unknown-horizons/unknown-horizons/horizons/gui/tabs/selectmultitab.py", line 78, in init_widget
    self.draw_selected_units_widget()
 File "/disk/src/github/unknown-horizons/unknown-horizons/horizons/gui/tabs/selectmultitab.py", line 102, in draw_selected_units_widget
    self.add_entry(UnitEntry([instance], False))
 File "/disk/src/github/unknown-horizons/unknown-horizons/horizons/gui/tabs/selectmultitab.py", line 92, in add_entry
    self.widget.findChild(name="hbox_{}".format(self.row_number).addChild(entry.widget))
AttributeError: 'str' object has no attribute 'addChild'